### PR TITLE
Adding capability to target ReadTheDocs for Business

### DIFF
--- a/v3/cmd/create_project/main.go
+++ b/v3/cmd/create_project/main.go
@@ -22,7 +22,7 @@ func main() {
 		flag.PrintDefaults()
 		os.Exit(1)
 	}
-	client := readthedocs.NewClient(os.Getenv("READTHEDOCS_TOKEN"), *apiBaseUrlFlag)
+	client := readthedocs.NewClientWithURL(os.Getenv("READTHEDOCS_TOKEN"), *apiBaseUrlFlag)
 	slug, err := client.CreateProject(context.Background(), readthedocs.CreateUpdateProject{
 		CreateProject:         readthedocs.CreateProject{Name: *nameFlag, Repository: readthedocs.Repository{URL: *repositoryFlag, Type: "git"}, Organization: *organizationFlag},
 		DefaultVersion:        "latest",

--- a/v3/cmd/create_project/main.go
+++ b/v3/cmd/create_project/main.go
@@ -13,6 +13,8 @@ import (
 
 var nameFlag = flag.String("name", "", "Name of the project.")
 var repositoryFlag = flag.String("repository", "", "URL of the repository.")
+var organizationFlag = flag.String("organization", "", "(OPTIONAL) ReadTheDocs for Business organization where the project should be created.")
+var apiBaseUrlFlag = flag.String("base_url", "https://readthedocs.org/api/v3", "ReadTheDocs API base URL. Can be used to target the Read The Docs For Business API.")
 
 func main() {
 	flag.Parse()
@@ -20,9 +22,9 @@ func main() {
 		flag.PrintDefaults()
 		os.Exit(1)
 	}
-	client := readthedocs.NewClient(os.Getenv("READTHEDOCS_TOKEN"))
+	client := readthedocs.NewClient(os.Getenv("READTHEDOCS_TOKEN"), *apiBaseUrlFlag)
 	slug, err := client.CreateProject(context.Background(), readthedocs.CreateUpdateProject{
-		CreateProject:         readthedocs.CreateProject{Name: *nameFlag, Repository: readthedocs.Repository{URL: *repositoryFlag, Type: "git"}},
+		CreateProject:         readthedocs.CreateProject{Name: *nameFlag, Repository: readthedocs.Repository{URL: *repositoryFlag, Type: "git"}, Organization: *organizationFlag},
 		DefaultVersion:        "latest",
 		DefaultBranch:         "main",
 		AnalyticsCode:         "",

--- a/v3/cmd/read_projects/main.go
+++ b/v3/cmd/read_projects/main.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"log"
 	"os"
@@ -10,8 +11,11 @@ import (
 	"github.com/BarnabyShearer/readthedocs/v3"
 )
 
+var apiBaseUrlFlag = flag.String("base_url", "https://readthedocs.org/api/v3", "ReadTheDocs API base URL. Can be used to target the Read The Docs For Business API.")
+
 func main() {
-	client := readthedocs.NewClient(os.Getenv("READTHEDOCS_TOKEN"))
+	flag.Parse()
+	client := readthedocs.NewClient(os.Getenv("READTHEDOCS_TOKEN"), *apiBaseUrlFlag)
 	projects, err := client.GetProjects(context.Background())
 	if err != nil {
 		log.Fatal(err)

--- a/v3/cmd/read_projects/main.go
+++ b/v3/cmd/read_projects/main.go
@@ -15,7 +15,7 @@ var apiBaseUrlFlag = flag.String("base_url", "https://readthedocs.org/api/v3", "
 
 func main() {
 	flag.Parse()
-	client := readthedocs.NewClient(os.Getenv("READTHEDOCS_TOKEN"), *apiBaseUrlFlag)
+	client := readthedocs.NewClientWithURL(os.Getenv("READTHEDOCS_TOKEN"), *apiBaseUrlFlag)
 	projects, err := client.GetProjects(context.Background())
 	if err != nil {
 		log.Fatal(err)

--- a/v3/main.go
+++ b/v3/main.go
@@ -12,9 +12,6 @@ import (
 	"time"
 )
 
-// APIs default base URL.
-const BaseURLV3 = "https://readthedocs.org/api/v3"
-
 type Client struct {
 	BaseURL    string
 	apiKey     string
@@ -22,9 +19,9 @@ type Client struct {
 }
 
 // Create the API client, providing the authentication key.
-func NewClient(apiKey string) *Client {
+func NewClient(apiKey string, baseUrl string) *Client {
 	return &Client{
-		BaseURL: BaseURLV3,
+		BaseURL: baseUrl,
 		apiKey:  apiKey,
 		HTTPClient: &http.Client{
 			Timeout: time.Minute,
@@ -83,6 +80,8 @@ type CreateProject struct {
 	Homepage            string     `json:"homepage,omitempty"`
 	ProgrammingLanguage string     `json:"programming_language,omitempty"`
 	Language            string     `json:"language,omitempty"`
+	Organization        string     `json:"organization,omitempty"`
+	Teams               string     `json:"teams,omitempty"`
 }
 
 type CreateUpdateProject struct {

--- a/v3/main.go
+++ b/v3/main.go
@@ -12,14 +12,22 @@ import (
 	"time"
 )
 
+// APIs default base URL.
+const BaseURLV3 = "https://readthedocs.org/api/v3"
+
 type Client struct {
 	BaseURL    string
 	apiKey     string
 	HTTPClient *http.Client
 }
 
-// Create the API client, providing the authentication key.
-func NewClient(apiKey string, baseUrl string) *Client {
+// Create the API client using the default URL, providing the authentication key.
+func NewClient(apiKey string) *Client {
+	return NewClientWithURL(apiKey, BaseURLV3)
+}
+
+// Create the API client using a custom URL, providing the authentication key.
+func NewClientWithURL(apiKey string, baseUrl string) *Client {
 	return &Client{
 		BaseURL: baseUrl,
 		apiKey:  apiKey,


### PR DESCRIPTION
ReadTheDocs has two main endpoints:
`https://readthedocs.org/` and
`https://readthedocs.com/`
as per [their docs](https://docs.readthedocs.io/en/stable/commercial/index.html#read-the-docs-for-business)

Adding support for the Business endpoint is fairly easy. I have taken the approach to make the base URL configurable in your code, mostly because this is how it is done in the GitHub and a few other SDKs. I also made changes to the rest of the code that references the constructor.

I will also raise a PR for the terraform provider code.